### PR TITLE
docs: add reusable repository documentation standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-07-22 - repository-documentation-standard v1.0.0
+**What:** Added the CP7 Reusable Repository Documentation Standard under
+`docs/standards/repository-documentation/` (STANDARD, TERMINOLOGY, ADOPTION,
+AUDIT, MAINTENANCE, PROJECT-INVENTORY, 8 templates, minimal-tree example) plus
+`scripts/repo-doc-check`, `scripts/repo-doc-audit`, and fixture tests under
+`scripts/repo-doc-tests/`. Generalized from the Empower documentation model.
+**Why:** Give every CP7 repo a reusable, agent-agnostic documentation standard
+with a deterministic read-only checker, without copying Empower-specific details.
+**Verification:** `bash scripts/repo-doc-tests/run-tests.sh` (11/11 PASS);
+`python3 -m py_compile` on both tools; `git diff --check`.
+**Scope:** standard + tooling + inventory only — no other project migrated.
+**Agent:** Claude Code (Opus 4.8)
+**Standard version:** 1.0.0
+
 ## 2026-05-06 - Agent standards compliance
 **What:** Added missing AGENTS.md sections (Purpose, Architecture, Agents and Crons, Gotchas, Decisions) and created CHANGELOG.md to comply with CP7 Agent Operating Standard v1.
 **Why:** Project was missing required standard sections and had no change log.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ A template repository for planning, specifying, and executing software projects 
     └── 001-example.md     # Post-task review notes
 ```
 
+## Reusable Repository Documentation Standard
+
+This repo also hosts the **CP7 Reusable Repository Documentation Standard** — a
+reusable, agent-agnostic standard for how any CP7 repo documents itself (canonical
+`AGENTS.md`, doc lifecycle, terminology, templates, and a read-only docs checker).
+
+- Standard: [`docs/standards/repository-documentation/STANDARD.md`](docs/standards/repository-documentation/STANDARD.md)
+- Tools: [`scripts/repo-doc-check`](scripts/repo-doc-check) (deterministic gate) and [`scripts/repo-doc-audit`](scripts/repo-doc-audit) (read-only audit)
+
+It governs *documentation structure only*; it references (does not restate) the
+Agent Control Plane runtime rules and this repo's own `PLAYBOOK.md` workflow.
+
 ## Key Principles
 
 - **Planning is the product.** The spec is written before any code. The agent executes, it doesn't design.

--- a/docs/standards/repository-documentation/ADOPTION.md
+++ b/docs/standards/repository-documentation/ADOPTION.md
@@ -1,0 +1,73 @@
+# Adoption Procedure
+
+Part of the [CP7 Reusable Repository Documentation Standard](STANDARD.md).
+
+Adopt the standard **one project at a time**. Empower is the reference
+implementation — study how it applied the pattern, but never blind-copy its
+paths, ports, services, or data rules into another repo.
+
+## Principles
+
+- **Read before write.** Every adoption starts with a read-only audit and a set
+  of human decisions. No repository is mass-rewritten sight-unseen.
+- **Reconcile with reality.** The docs must match the project's *actual*
+  topology (services, deploy model, worktrees — or the absence of them). A
+  project with no database/frontend/service/worktree manager must not inherit
+  rules that assume them.
+- **One task branch/worktree per adoption.** Same discipline as any other
+  change: isolated worktree, focused commit, review.
+
+## Stages
+
+### 1. Read-only audit
+Run `repo-doc-audit --root <project> > audit-<project>-<date>.md` (write it
+outside the repo). Run `repo-doc-check` for the deterministic baseline. Answer
+the semantic prompt (source-of-truth conflicts, stale docs, dangerous
+instructions, per-file disposition). **No file changes in this stage.**
+
+### 2. Reconcile actual topology
+Confirm what the project really is: language, run/deploy model, whether it uses
+specs, whether it has harness adapters, what its real production-safety rules
+are. Note anything the generic baseline should *not* impose here.
+
+### 3. Approve terminology & human decisions
+Take the unknown-decision list from stage 1 to Chris: which file is canonical
+for each fact, what to retire, any terminology renames, whether the project
+tracks specs/roadmap. Record the answers.
+
+### 4. Create a project-specific implementation SPEC
+Write a SPEC (use [templates/SPEC.template.md](templates/SPEC.template.md)) that
+lists the exact, reviewed changes: canonical `AGENTS.md`, thin adapters,
+`docs/INDEX.md`, HANDOFF trim, roadmap, spec lifecycle if used, and a tuned
+`.repo-doc.json`. The SPEC is the reviewable plan — not an open-ended "clean up
+the docs."
+
+### 5. Migrate in a task branch/worktree
+Execute the SPEC in an isolated worktree. Move history to archive with
+tombstones; never delete load-bearing records. Keep the diff focused on docs.
+
+### 6. Add project-appropriate checks
+Commit a `.repo-doc.json` tuned to the project. Verify `repo-doc-check` passes.
+Add fixtures only if the project needs project-specific rules.
+
+### 7. Review / merge / deploy *only if relevant*
+Open a PR if review adds value; otherwise follow the project's normal ship path.
+Documentation changes rarely need a deploy — do not trigger one unless the
+project genuinely couples docs to runtime.
+
+### 8. Post-merge verification & cleanup
+Re-run `repo-doc-check` on the merged result. Remove the task worktree. Confirm
+no runtime/service/data state changed.
+
+## Guardrails
+
+- **Never** migrate more than one project per task.
+- **Never** skip the stage-1 audit or the stage-3 human decisions.
+- **Never** import Empower-specific commands, ports, or paths into a generic
+  project's `AGENTS.md`.
+- If adopting would require modifying another project or any runtime state to
+  make the kit "work," **stop and report** — the kit must be adoptable without
+  touching production.
+
+See [MAINTENANCE.md](MAINTENANCE.md) for keeping a project compliant afterward,
+and [PROJECT-INVENTORY.md](PROJECT-INVENTORY.md) for the recommended order.

--- a/docs/standards/repository-documentation/AUDIT.md
+++ b/docs/standards/repository-documentation/AUDIT.md
@@ -1,0 +1,132 @@
+# Read-Only Audit & Checker Configuration
+
+Part of the [CP7 Reusable Repository Documentation Standard](STANDARD.md).
+
+This document covers the two tools and how to configure them. Both are
+**read-only** and require **no network** and **no third-party packages**.
+
+## `repo-doc-check` — deterministic gate
+
+```bash
+# from the repo you want to check (uses git toplevel automatically):
+scripts/repo-doc-check
+
+# or explicitly:
+scripts/repo-doc-check --root /path/to/repo --config /path/to/.repo-doc.json
+
+# discover what it does:
+scripts/repo-doc-check --help
+scripts/repo-doc-check --list-checks
+scripts/repo-doc-check --print-config     # effective config after defaults merge
+```
+
+Exit code: **0 = PASS**, **1 = FAIL**, **2 = usage/config error**. Output ends
+with exactly `result: PASS (...)` or `result: FAIL (...)`. Warnings never fail
+the run.
+
+### Configuration schema (`.repo-doc.json`)
+
+Every key is optional. With no file present, built-in defaults apply — a small
+repo needs no config. Deep-merged over the defaults, so you only override what
+differs. Run `--print-config` to see the effective result.
+
+```jsonc
+{
+  // Files that MUST exist. Default: ["README.md", "AGENTS.md"].
+  "required_files": ["README.md", "AGENTS.md", "docs/INDEX.md"],
+
+  // The one canonical agent-instruction file every adapter must point at.
+  "canonical_agents_file": "AGENTS.md",
+
+  // Active-work tracker size budget. required:false => absence is OK.
+  "handoff": {
+    "file": "HANDOFF.md",
+    "required": false,
+    "warn_lines": 200,
+    "fail_lines": 400
+  },
+
+  // Documentation index. must_reference: substrings that must appear in it.
+  "index": {
+    "file": "docs/INDEX.md",
+    "required": false,
+    "must_reference": ["AGENTS.md"]
+  },
+
+  // SPEC lifecycle. Leave disabled if the project uses no specs.
+  "specs": {
+    "enabled": false,
+    "active_dir": "docs/specs/active",
+    "completed_dir": "docs/specs/completed",
+    "archive_dir": "docs/specs/archive",
+    "status_scan_lines": 45
+  },
+
+  // Thin harness adapters (globs allowed). Any present must reference the
+  // canonical file. require_at_least_one:false => zero adapters is valid.
+  "adapters": {
+    "candidates": [".cursor/rules/*.mdc", "GEMINI.md", "CLAUDE.md", ".codex/AGENTS.md"],
+    "require_at_least_one": false
+  },
+
+  // Relative-link / path-reference check (in-repo scope only, no network).
+  "link_check": {
+    "enabled": true,
+    "scan": ["AGENTS.md", "README.md", "docs/INDEX.md", "ROADMAP.md"],
+    "allowlist": ["path/that/exists/only/at/runtime"]
+  },
+
+  // Uncontrolled filenames to reject (globs, matched on basename, case-insensitive).
+  "forbidden_filenames": ["FINAL_NOTES.md", "LATEST_PLAN.md", "NEW_HANDOFF.md", "FINAL_*.md"],
+
+  // Project-specific stale terms to flag inside scanned docs.
+  "forbidden_terms": ["retired-service-name", ":OLD_PORT"],
+
+  // Directories never scanned.
+  "ignore_dirs": [".git", "node_modules", "venv", ".venv", "dist", "build"]
+}
+```
+
+### Small vs complex projects
+
+- **Small script/CLI repo:** no `.repo-doc.json` at all. The defaults require
+  only `README.md` + `AGENTS.md`, allow no HANDOFF, and expect no specs.
+- **Complex multi-service repo:** enable `specs`, require `docs/INDEX.md`, add
+  the project's real harness adapters, tighten the HANDOFF budget, and list
+  project-specific `forbidden_terms` (e.g. a retired port or service name).
+
+Prefer **configuration over editing the script**. The same generic
+`repo-doc-check` serves every project; per-project behavior comes from
+`.repo-doc.json`.
+
+## `repo-doc-audit` — read-only inventory + semantic prompt
+
+```bash
+scripts/repo-doc-audit --root /path/to/repo > audit-<project>-<date>.md
+scripts/repo-doc-audit --help
+```
+
+It writes Markdown to stdout (write the report **outside** the repo, or into a
+task branch you will review — never committed as a stray file). It has two parts:
+
+1. **Deterministic inventory (facts):** every Markdown file, canonical files
+   present/absent, harness adapters, SPEC lifecycle state, and the full
+   `repo-doc-check` output.
+2. **Semantic audit prompt (judgment):** the questions the tools cannot answer —
+   source-of-truth conflicts, link/reference *intent* tracing, stale-vs-current
+   classification, dangerous operational instructions, per-file disposition
+   recommendations, and unknown human decisions.
+
+> **The tool never claims to have resolved a semantic question.** Part 2 must be
+> answered by an agent or human. Do not treat a clean `repo-doc-check` as proof
+> the documentation is *correct* — only that it is structurally valid.
+
+## What the deterministic tools deliberately do NOT do
+
+- Decide which of two conflicting docs is canonical.
+- Judge whether prose is stale, misleading, or dangerous.
+- Follow links to external hosts or validate their contents.
+- Modify, move, or delete anything.
+
+Those are semantic-audit and human-decision responsibilities, by design (see
+[MAINTENANCE.md](MAINTENANCE.md) for cadence).

--- a/docs/standards/repository-documentation/MAINTENANCE.md
+++ b/docs/standards/repository-documentation/MAINTENANCE.md
@@ -1,0 +1,65 @@
+# Maintenance Procedure
+
+Part of the [CP7 Reusable Repository Documentation Standard](STANDARD.md).
+
+How documentation cleanliness persists after a project adopts the standard, and
+how the shared standard itself evolves.
+
+## Keeping a project clean
+
+1. **Docs check in closeout gates.** Add `repo-doc-check` to the project's
+   pre-push / closeout gate (alongside its tests). A failing docs check blocks
+   the same way a failing test does.
+2. **Optional CI integration.** Projects with CI may run `repo-doc-check` on push
+   and PR. It is read-only and needs no secrets or network. Keep it a *separate*
+   step so a docs failure is legible. (This is optional — not every repo has or
+   wants CI.)
+3. **Index-or-exempt for new Markdown.** A new doc must be added to
+   `docs/INDEX.md` (or explicitly exempted in `.repo-doc.json`). Unindexed docs
+   are how drift starts.
+4. **Active-work budgets.** Respect the `HANDOFF.md` size budget; archive closed
+   sessions when it warns. Re-confirm or archive stale active SPECs (> 30 days
+   idle).
+5. **Periodic semantic audit.** `repo-doc-check` catches structure, not meaning.
+   Run `repo-doc-audit` and answer its semantic prompt on a cadence — suggested
+   **quarterly**, or before a major refactor / handoff to a new maintainer.
+
+## Owning changes to the standard
+
+- **Owner:** Chris. The standard is hosted in `project-playbook`
+  (`docs/standards/repository-documentation/`) and changes go through that
+  repo's normal review.
+- **Scope discipline:** the standard governs documentation only. Runtime/agent
+  gating changes belong in ACP; workflow-process changes belong in
+  `project-playbook`'s `PLAYBOOK.md`. Do not absorb those concerns here.
+
+## Versioning & changelog
+
+- The standard is **semver-versioned** in `STANDARD.md` (currently `1.0.0`).
+- **PATCH** — wording, examples, non-behavioral checker fixes.
+- **MINOR** — new optional checks, new templates, new config keys with safe
+  defaults (existing repos keep passing).
+- **MAJOR** — a change that can make a previously-passing repo fail (e.g. a new
+  required file, a stricter default). Requires migration notes.
+- Record every change in the host repo's `CHANGELOG.md` under a
+  `repository-documentation-standard` heading, with the version bump.
+
+## Migration notes (when terminology or defaults change)
+
+When a change could break adopted projects:
+
+1. State the change and the version in `CHANGELOG.md`.
+2. Provide the exact `.repo-doc.json` override that restores prior behavior, so a
+   project can adopt the new version on its own schedule.
+3. Never silently tighten a default — a MINOR release must keep existing repos
+   green; only a MAJOR may require action, and only with migration notes.
+
+## Drift-prevention summary
+
+| Mechanism | Catches |
+|---|---|
+| `repo-doc-check` in closeout gate | structural drift (missing files, broken links, bad adapters, oversized HANDOFF, forbidden names) |
+| Index-or-exempt rule | orphaned new docs |
+| Active-work budgets | HANDOFF bloat, zombie SPECs |
+| Quarterly `repo-doc-audit` | semantic drift (conflicts, stale prose, dangerous instructions) |
+| Semver + changelog + migration notes | the standard drifting from its adopters |

--- a/docs/standards/repository-documentation/PROJECT-INVENTORY.md
+++ b/docs/standards/repository-documentation/PROJECT-INVENTORY.md
@@ -1,0 +1,79 @@
+# Project Inventory & Rollout Waves
+
+Part of the [CP7 Reusable Repository Documentation Standard](STANDARD.md).
+
+A **read-only, high-level** inventory of current version-controlled CP7 projects
+and a recommended adoption order. This is a triage map, **not** a deep audit —
+per-project auditing happens at [ADOPTION.md](ADOPTION.md) stage 1, one project
+at a time. Nothing here changes any project's state.
+
+**Method:** read-only presence scan (`AGENTS.md`, `README.md`, `docs/INDEX.md`,
+`HANDOFF.md`, `ROADMAP.md`, CI workflows, harness adapters) across the projects
+listed in `/home/chris/AGENT_INDEX.md`. Scanned 2026-07-22.
+
+Legend — **A**=AGENTS.md · **R**=README · **I**=docs/INDEX.md · **H**=HANDOFF ·
+**M**=ROADMAP · **CI**=.github/workflows · **Ad**=harness adapter(s).
+Risk = documentation drift risk / cleanup effort. Sens = operational
+sensitivity (live/prod exposure).
+
+## Inventory
+
+| Project | Type (high level) | A | R | I | H | M | CI | Ad | Doc risk | Sens | Wave |
+|---|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| empower | full-stack finance app | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **Reference** | High | — (done) |
+| project-playbook | template / methodology (host) | ✓ | ✓ | – | ✓ | – | ✓ | – | Low | Low | **1** |
+| playbook-cli | Python CLI (no service) | ✓ | ✓ | – | ✓ | – | ✓ | – | Low | Low | **1** |
+| cc-loop | agent tooling | ✓ | ✓ | – | ✓ | – | – | – | Low | Low | **1** |
+| 531-pwa | frontend PWA | ✓ | ✓ | – | ✓ | – | ✓ | – | Medium | Low | **1** |
+| service-register | small Python service | ✓ | ✓ | – | ✓ | – | – | – | Low | Medium | **1** |
+| dashboard | frontend app | ✓ | ✓ | – | ✓ | – | ✓ | – | Medium | Medium | 2 |
+| cp7-mobile | React Native / Expo app | ✓ | ✓ | – | ✓ | – | ✓ | CLAUDE | Medium | Low | 2 |
+| gitview | Docker service | ✓ | ✓ | – | ✓ | – | – | – | Medium | Medium | 2 |
+| mfd-dashboard | Docker dashboard | ✓ | ✓ | – | ✓ | – | – | – | Medium | Medium | 2 |
+| bosgame-mcp | MCP server | ✓ | ✓ | – | ✓ | – | – | – | Medium | Medium | 2 |
+| skill-updates | tooling / docs | ✓ | ✓ | – | ✓ | – | – | – | Medium | Low | 2 |
+| autochain | tooling | ✓ | ✓ | – | ✓ | – | – | – | Medium | Low | 2 |
+| acerserver-maintenance | ops / scripts | ✓ | ✓ | – | ✓ | – | – | – | Medium | Medium | 2 |
+| session-broker | Python service | ✓ | ✓ | – | ✓ | – | ✓ | – | Medium | Medium | 2 |
+| netmon | monitoring daemon | ✓ | ✓ | – | ✓ | – | ✓ | – | Medium | High | 3 |
+| context-engine-v2 | live Python service (:8402) | ✓ | ✓ | – | ✓ | – | ✓ | – | High | High | 3 |
+| session/honcho | Docker memory stack | ✓ | ✓ | – | ✓ | – | ✓ | – | High | High | 3 |
+| firecrawl | Docker service (fork) | ✓ | ✓ | – | ✓ | – | ✓ | – | High | High | 3 |
+| hermes-workspace | agent gateway (Docker) | ✓ | ✓ | – | ✓ | – | ✓ | – | High | High | 3 |
+
+> The full index lists additional non-project roots (docker service dirs,
+> dotfiles, wiki, scripts). Those are out of scope for this standard unless a
+> given one is genuinely a documented project.
+
+## Fleet-wide observations (deterministic)
+
+- **Near-universal baseline already exists:** almost every project has
+  `AGENTS.md` + `README.md` + `HANDOFF.md`. Good starting point.
+- **The consistent gap:** no `docs/INDEX.md`, no vetted `ROADMAP.md`, no spec
+  lifecycle, and no docs check anywhere except **empower** (the reference).
+- **Harness adapters are rare** (only empower and cp7-mobile) — meaning most
+  repos correctly rely on direct `AGENTS.md` consumption, which the standard
+  endorses.
+- **HANDOFF freshness is the likely per-project cleanup** — several may hold
+  stale active entries; that is a stage-1 audit finding, not asserted here.
+
+## Recommended first rollout wave (5)
+
+Chosen for **manageable risk + representativeness** — they cover the distinct
+project archetypes so the standard proves itself across shapes before touching
+anything production-sensitive:
+
+1. **project-playbook** — dogfood the standard in the repo that hosts it; a
+   template repo, lowest risk.
+2. **playbook-cli** — a pure Python CLI (no service, no DB, no frontend): proves
+   the "small project" baseline and the no-worktree/no-deploy path.
+3. **531-pwa** — a frontend PWA: proves the standard on a JS/build-tool project.
+4. **cc-loop** — agent tooling: proves it on an agent-facing repo where the
+   `AGENTS.md`-as-canon contract matters most.
+5. **service-register** — a small backend service: proves the conditional
+   operations/deployment docs without high production stakes.
+
+**Explicitly deferred to later waves:** the live/prod-sensitive services
+(context-engine-v2, honcho, firecrawl, hermes-workspace, netmon) — Wave 3, each
+with a careful stage-1 audit — and empower, which is already the reference
+implementation and needs no adoption.

--- a/docs/standards/repository-documentation/STANDARD.md
+++ b/docs/standards/repository-documentation/STANDARD.md
@@ -1,0 +1,177 @@
+# CP7 Reusable Repository Documentation Standard
+
+**Version:** 1.0.0 · **Status:** Active · **Owner:** Chris (see [MAINTENANCE.md](MAINTENANCE.md))
+
+A reusable, agent-agnostic standard for how a CP7 repository documents itself so
+that any human or any agent/harness can orient quickly, find the one true source
+for each fact, and avoid acting on stale or conflicting instructions.
+
+This standard is the **generalized** form of the model proven in the Empower
+repository (PRs #453–#460). Empower is the *reference implementation*, not a
+template to copy — nothing Empower-specific (paths, ports, services, database
+rules, product details) belongs in a generic project.
+
+## What this is and is not
+
+- **It governs documentation structure** — which docs exist, what each means,
+  how work moves through them, and a read-only check that catches drift.
+- **It does not govern agent runtime behavior.** Agent safety gates, task
+  levels, routing, and worktree rules live in the Agent Control Plane (ACP,
+  `agent-control-plane/source/rules/` → the rendered `CLAUDE.md`). This standard
+  **references** that authority; it does not restate it. See
+  [Separation of concerns](#separation-of-concerns).
+
+## Read next
+
+| Doc | Purpose |
+|---|---|
+| [TERMINOLOGY.md](TERMINOLOGY.md) | Exact meaning of every doc term; prohibited names |
+| [ADOPTION.md](ADOPTION.md) | Staged, one-project-at-a-time rollout procedure |
+| [AUDIT.md](AUDIT.md) | Read-only audit + full `repo-doc-check` config schema |
+| [MAINTENANCE.md](MAINTENANCE.md) | How cleanliness persists; versioning of this standard |
+| [PROJECT-INVENTORY.md](PROJECT-INVENTORY.md) | Current projects + recommended rollout waves |
+| [templates/](templates/) | Concise, fill-in templates for every doc type |
+| [examples/minimal-project-tree.md](examples/minimal-project-tree.md) | The smallest compliant repo |
+
+Tools: [`scripts/repo-doc-check`](../../../scripts/repo-doc-check) (deterministic
+gate) and [`scripts/repo-doc-audit`](../../../scripts/repo-doc-audit) (read-only
+inventory + semantic audit prompt).
+
+---
+
+## 1. Universal rules (every repository)
+
+These are the small, non-negotiable baseline. They fit a one-file script repo as
+well as a multi-service app.
+
+1. **One canonical agent-instruction file: `AGENTS.md`.** It is the source of
+   truth for how to work in the repo. It is hand-authored and self-contained
+   enough to orient a cold agent.
+2. **A `README.md`** for humans — what the project is, how to run it.
+3. **Every harness adapter is thin and points at `AGENTS.md`.** `CLAUDE.md`,
+   `.cursor/rules/*.mdc`, `GEMINI.md`, `.codex/AGENTS.md`, etc. carry only
+   genuine harness-specific behavior. Shared policy is never copied into them.
+   The preferred `CLAUDE.md` form is a symlink to `AGENTS.md`.
+4. **One meaning per term** — [TERMINOLOGY.md](TERMINOLOGY.md) governs. No
+   uncontrolled `FINAL_*/LATEST_*/NEW_*` files.
+5. **One SoT per fact.** If two files state the same rule, one is canonical and
+   the other references it. Conflicts are drift.
+6. **Active work is tracked and closed out.** While work is in flight it has a
+   `HANDOFF.md` entry; when it stops, the entry is closed (shipped, archived, or
+   abandoned) — not left dangling.
+7. **History is labeled.** Anything no longer current truth is archived and
+   explicitly marked historical, or left as a tombstone/redirect stub.
+8. **Docs are checkable.** `repo-doc-check` runs clean (read-only, no network).
+
+## 2. Required vs optional structure
+
+**Required baseline** (small; suitable for most repositories):
+
+| File / location | When required |
+|---|---|
+| `README.md` | always |
+| `AGENTS.md` | always |
+| `docs/INDEX.md` | when the repo has more than a handful of docs (recommended once `docs/` exists) |
+| `HANDOFF.md` | **only while work is active** — absence is valid and correct when nothing is in flight |
+| `ROADMAP.md` (or approved equivalent) | when the project tracks future work |
+| `docs/specs/{active,completed,archive}/` | when the project uses specifications |
+
+**Conditional / optional** — add only when the project actually needs it:
+
+architecture docs, testing/gate docs, `docs/OPERATIONS.md`, deployment docs,
+`docs/decisions/` ADRs, implementation reports, `CHANGELOG.md`, harness
+adapters.
+
+> **Do not create empty files to satisfy a template.** A missing optional doc is
+> correct when there is nothing to say. The checker never requires an optional
+> file to exist.
+
+## 3. Agent / harness contract
+
+- **One canonical instruction source** (`AGENTS.md`), consumed directly by every
+  harness that supports it (Codex, OpenCode, and others read `AGENTS.md`
+  natively — they need no adapter at all).
+- **Thin adapters only for genuine harness behavior.** If a harness needs a file,
+  it points at `AGENTS.md` and adds only what is specific to that harness.
+- **No copied shared policy** across Claude / Cursor / Gemini / Codex / OpenCode
+  / Bob-Hermes files. Duplication is the failure mode; a checker rule enforces
+  that every adapter references the canonical file.
+- **Clear startup / read-first order** stated at the top of `AGENTS.md`.
+- **Project-specific production-safety rules live in the project's own canon**
+  (`AGENTS.md` / `docs/OPERATIONS.md`) — never hard-coded into this generic
+  standard, which knows nothing about any project's services or data.
+
+## 4. Document lifecycle
+
+Work moves in one direction; each stage has one home:
+
+```text
+ROADMAP / backlog            (vetted intent)
+  → active SPEC              (docs/specs/active/, has Status:)
+  → HANDOFF entry            (while actively worked)
+  → implementation report    (what actually happened)
+  → completed SPEC or archive (docs/specs/completed/ or archive/)
+  → CHANGELOG                (only for completed / released changes)
+```
+
+**Closeout is mandatory.** When work stops, the active SPEC moves to
+completed/archive, the `HANDOFF.md` entry is resolved, and (if released) a
+`CHANGELOG.md` line is added. A relocated SPEC leaves a tombstone stub at its old
+path.
+
+**Stale-entry budgets** (defaults; tune per project in `.repo-doc.json`):
+
+- `HANDOFF.md`: target ≤ 200 lines (warn), hard fail > 400. Over the warn
+  budget → archive the oldest closed sessions.
+- Active SPECs with no movement for > 30 days → re-confirm on the roadmap or move
+  to archive.
+
+## 5. Deterministic validation — `repo-doc-check`
+
+A generic, configurable, **read-only** checker (see [AUDIT.md](AUDIT.md) for the
+config schema). It performs only checks that are true/false by inspection:
+
+required canonical files · broken relative Markdown links & path refs (in-repo
+scope) · invalid lifecycle placement · missing `Status:` in active/completed
+SPECs · `HANDOFF.md` size budget · missing index references · adapters that fail
+to reference `AGENTS.md` · forbidden/uncontrolled filenames · configured stale
+terms. It prints `OK/WARN/FAIL` lines and a final **`result: PASS`** or
+**`result: FAIL`**, exiting non-zero on failure.
+
+Guarantees: **no repository mutation · no network by default · no new
+dependencies** (Python standard library only). Configuration scales from a
+zero-config small repo to a complex multi-service one. Fixtures cover both
+passing and failing cases (`scripts/repo-doc-tests/`).
+
+## 6. Read-only semantic audit — `repo-doc-audit`
+
+Deterministic checks cannot resolve *meaning*. `repo-doc-audit` produces a
+read-only inventory (every doc, canonical files, adapters, SPEC lifecycle, and
+the `repo-doc-check` result) **plus a semantic audit prompt** for the questions
+that require judgment: source-of-truth conflicts, stale-vs-current
+classification, dangerous operational instructions, per-file disposition, and
+unknown human decisions.
+
+> The audit is complete only after a human/agent answers the semantic prompt.
+> **No regex or link check can certify semantic correctness.**
+
+## 7. Adoption & maintenance
+
+Rollout is staged and **one project at a time** — see [ADOPTION.md](ADOPTION.md).
+Cleanliness is kept via closeout gates, optional CI, and periodic audits — see
+[MAINTENANCE.md](MAINTENANCE.md).
+
+---
+
+## Separation of concerns
+
+| Concern | Authority | This standard's role |
+|---|---|---|
+| Documentation structure, terminology, lifecycle, doc-check | **This standard** | defines it |
+| Agent safety gates, task levels (L1–L3), routing, worktree rules, mobile-safe ops | **ACP** (`agent-control-plane/source/rules/`) | references it — never restates |
+| Project workflow (spec → task → build → verify), task files, review gates | **project-playbook** `PLAYBOOK.md` | integrates with it; this kit lives here |
+| Concrete project scaffolds (FastAPI/Flask) | **cp7-project-template** | orthogonal; a scaffolded project then adopts this standard |
+| ADR format | **project-playbook** `docs/decisions/ADR-template.md` | this kit's [ADR template](templates/ADR.template.md) shares that section set |
+
+This standard **integrates** existing CP7 governance; it does not duplicate it.
+Where another repo already owns a rule, this standard points at it.

--- a/docs/standards/repository-documentation/TERMINOLOGY.md
+++ b/docs/standards/repository-documentation/TERMINOLOGY.md
@@ -1,0 +1,43 @@
+# Repository Documentation — Canonical Terminology
+
+Part of the [CP7 Reusable Repository Documentation Standard](STANDARD.md).
+
+One word, one meaning. When these terms appear in any CP7 repository's docs,
+they mean exactly what is written here. Ambiguity is the drift this standard
+exists to prevent.
+
+## Terms
+
+| Term | Definition |
+|---|---|
+| **Current truth** | The state of the system *right now*. A doc describing current truth must match reality; if it describes something retired or planned, it is not current truth. |
+| **Canonical / source of truth (SoT)** | The single file that authoritatively defines a thing. Exactly one SoT per topic. Everything else references it; nothing restates it. `AGENTS.md` is the canonical agent-instruction SoT. |
+| **Backlog / roadmap** | Vetted, intended future work. Lives in `ROADMAP.md` (or a project-approved equivalent). Not a scratch list of every idea — items are triaged and worth doing. |
+| **Active / in flight** | Work a human or agent is doing *now* or will resume imminently. Tracked in `HANDOFF.md`. When work stops, its active entry is closed out, not left to rot. |
+| **Specification (SPEC)** | A written, reviewable definition of a discrete piece of work: objective, constraints, requirements, tests, gates. Has a `Status:` line. Moves through a lifecycle (active → completed/archive). |
+| **Report** | The record of what an executed SPEC actually did: files changed, tests run, results, remaining risks. Written once, at closeout. Immutable afterward. |
+| **Completed** | A SPEC whose work shipped and was verified. Moved to the completed location; its `Status:` says so. Not deleted — kept as a record. |
+| **Changelog / released change** | A dated, human-facing entry describing a change that actually shipped or released. `CHANGELOG.md`. Not a diary of in-progress work — only completed/released changes. |
+| **Decision / ADR** | An Architecture Decision Record: a durable note explaining *why* a non-obvious choice was made, its tradeoffs, and how to reverse it. Lives in `docs/decisions/`. |
+| **Archive / historical** | A record kept for history but no longer current truth. Explicitly labeled as historical. Readers must not act on it as current guidance. |
+| **Adapter** | A thin, harness-specific file (e.g. `CLAUDE.md`, `.cursor/rules/*.mdc`, `GEMINI.md`) that points a particular tool at the canonical `AGENTS.md`. It carries only genuine harness behavior — never a copy of shared policy. |
+| **Generated document** | A file produced by a script from another source. Marked "do not edit by hand." Regenerated, never hand-maintained. |
+| **Tombstone / redirect stub** | A small placeholder left where a file used to live, pointing to its new home (or stating it was retired). Prevents dead links and "where did it go?" confusion. |
+
+## Prohibited names
+
+These names (and similar uncontrolled variants) are **forbidden** — they signal
+drift and have no defined meaning in the lifecycle:
+
+- `FINAL_NOTES.md`, `LATEST_PLAN.md`, `NEW_HANDOFF.md`
+- `FINAL_*.md`, `*_FINAL.md`, `LATEST_*.md`, `NEW_*.md`, `*_NEW.md`
+- `*-old.md`, `*_old.md`, `*.md.bak`, `*copy*.md`
+
+If you need a plan, it is a `SPEC` or a `ROADMAP` entry. If you need to preserve
+history, it goes to the archive with an explicit historical label. There is no
+"final" or "latest" or "new" document — there is the canonical one.
+
+`repo-doc-check` enforces this list (configurable per project via
+`forbidden_filenames`). `TODO.md` is *discouraged* in favor of a vetted
+`ROADMAP.md`, but not forbidden by default — a project may keep it by
+configuration if it is genuinely maintained.

--- a/docs/standards/repository-documentation/examples/minimal-project-tree.md
+++ b/docs/standards/repository-documentation/examples/minimal-project-tree.md
@@ -1,0 +1,70 @@
+# Example — The Smallest Compliant Repository
+
+The standard scales down. A tiny script or CLI repo needs almost nothing.
+
+## Minimal passing tree
+
+```text
+my-tool/
+├── README.md          # what it is, how to run
+└── AGENTS.md          # canonical agent instructions
+```
+
+No `.repo-doc.json` is needed — the defaults require only `README.md` +
+`AGENTS.md`, allow the absence of `HANDOFF.md`, and expect no specs and no
+adapters.
+
+```bash
+$ scripts/repo-doc-check --root my-tool
+repo-doc-check (read-only) root=/.../my-tool
+config: built-in defaults
+----
+OK: required file present: README.md
+OK: required file present: AGENTS.md
+OK: path/link references checked: 2      # however many in-repo refs the docs contain
+OK: HANDOFF.md absent (no active work — allowed)
+OK: docs/INDEX.md absent (optional)
+OK: no harness adapters present (allowed)
+OK: no forbidden/uncontrolled filenames
+----
+result: PASS (0 warning(s))
+```
+
+## Growing into more structure
+
+Add pieces only when the project actually needs them:
+
+```text
+my-service/
+├── README.md
+├── AGENTS.md
+├── CLAUDE.md                 # thin adapter → symlink to AGENTS.md
+├── ROADMAP.md                # once there is a real backlog
+├── HANDOFF.md                # only while work is in flight
+├── .repo-doc.json            # enable specs, require docs/INDEX.md, tune budgets
+└── docs/
+    ├── INDEX.md
+    ├── OPERATIONS.md         # project-specific safety rules (the canon for them)
+    ├── decisions/
+    │   └── ADR-2026-07-22-example.md
+    └── specs/
+        ├── active/
+        │   └── first-feature.md      # has a Status: line
+        ├── completed/
+        └── archive/
+```
+
+A matching `.repo-doc.json` for that service:
+
+```json
+{
+  "required_files": ["README.md", "AGENTS.md", "docs/INDEX.md"],
+  "index": { "required": true, "must_reference": ["AGENTS.md"] },
+  "handoff": { "required": false, "warn_lines": 200, "fail_lines": 400 },
+  "specs": { "enabled": true },
+  "adapters": { "candidates": ["CLAUDE.md", ".cursor/rules/*.mdc"] }
+}
+```
+
+Everything above the required baseline is opt-in. **Never** create an empty file
+just to match this tree.

--- a/docs/standards/repository-documentation/templates/ADR.template.md
+++ b/docs/standards/repository-documentation/templates/ADR.template.md
@@ -1,0 +1,41 @@
+# ADR-YYYY-MM-DD: <Decision Title>
+
+> An Architecture Decision Record captures *why* a non-obvious choice was made.
+> This shares the section set of `project-playbook/docs/decisions/ADR-template.md`
+> — a project may use either; they are the same lineage. Lives in
+> `docs/decisions/`.
+
+## Status
+
+Proposed | Accepted | Superseded | Deprecated
+
+## Context
+
+What problem existed? What constraints mattered? What existing behavior is
+relevant?
+
+## Decision
+
+What choice was made?
+
+## Why
+
+Why this option instead of the alternatives considered?
+
+## Tradeoffs
+
+What improves? What gets worse? What could break?
+
+## Verification
+
+Commands or checks used to confirm the change (delete if purely a doc/process
+decision).
+
+## Rollback
+
+Exact steps to undo the change safely.
+
+## Related
+
+- Files: `<path>`
+- Services / ports / hostnames: `<or delete if N/A>`

--- a/docs/standards/repository-documentation/templates/AGENTS.template.md
+++ b/docs/standards/repository-documentation/templates/AGENTS.template.md
@@ -1,0 +1,55 @@
+# AGENTS.md — <Project Name>
+
+> Canonical agent-instruction source for this repo. Every harness adapter points
+> here; nothing restates this file. Keep it self-contained enough to orient a
+> cold agent. Delete any section below that does not apply — do not keep empty
+> headings.
+
+## Purpose
+
+<One paragraph: what this project is, who/what it serves, and its role in CP7.>
+
+## Read first (startup order)
+
+1. This file (`AGENTS.md`).
+2. `README.md` — human overview / how to run.
+3. `HANDOFF.md` — current active work (only exists while work is in flight).
+4. `docs/INDEX.md` — where every doc lives (if present).
+5. `<any project-specific must-read, e.g. docs/OPERATIONS.md>`.
+
+## Key facts
+
+- **Language / stack:** <...>
+- **Run:** `<command>`
+- **Test:** `<command>`
+- **Build:** `<command, if any>`
+- **Deploy model:** <none / manual / CI — describe, or delete if N/A>
+- **Ports / URLs:** <or delete if N/A>
+
+## Repo layout (conventions, not a full tree)
+
+- `<path>` — <what lives here / the one rule about it>
+
+## Safety rules (project-specific — this is the canon for them)
+
+> State the project's real production-safety rules here (what must never be done
+> without explicit human approval: restarts, live-data writes, migrations,
+> deploys). These belong in the project canon, not in the shared standard.
+> Delete this section for a project with no live/prod surface.
+
+- <rule>
+
+## Workflow
+
+<How work is done here: branch/worktree convention (or "no worktrees — commit on
+a branch"), test gate, ship path. Reference the ACP task levels and
+project-playbook workflow rather than restating them.>
+
+## Gotchas / lessons
+
+- <non-obvious thing that has bitten someone>
+
+---
+*Documentation follows the CP7 Repository Documentation Standard
+(`project-playbook/docs/standards/repository-documentation/STANDARD.md`). Run
+`repo-doc-check` before closeout.*

--- a/docs/standards/repository-documentation/templates/HANDOFF.template.md
+++ b/docs/standards/repository-documentation/templates/HANDOFF.template.md
@@ -1,0 +1,20 @@
+# HANDOFF
+
+> **Active work only.** This file exists while something is in flight. Keep it
+> small (target ≤ 200 lines). When a session closes, resolve its entry — ship,
+> archive the SPEC, or mark abandoned. Archive old sessions when over budget.
+> If there is no active work, this file can be absent.
+
+## Active now
+
+| Item | Branch / worktree | Status | Next step |
+|---|---|---|---|
+| <task> | <branch> | <in progress / blocked> | <the single next action> |
+
+## Recent sessions (short tail)
+
+- **<date>** — <what was done in one line>. <link to SPEC/report if any>.
+
+## Gotchas surfaced this cycle
+
+- <anything the next session must know>

--- a/docs/standards/repository-documentation/templates/INDEX.template.md
+++ b/docs/standards/repository-documentation/templates/INDEX.template.md
@@ -1,0 +1,28 @@
+# Documentation Index
+
+The map of this repo's documentation. If a doc exists and matters, it is listed
+here. New Markdown files must be added here (or exempted in `.repo-doc.json`).
+
+## Sources of truth
+
+| Topic | Canonical file |
+|---|---|
+| Agent instructions | `AGENTS.md` |
+| Human overview | `README.md` |
+| Active work | `HANDOFF.md` (only while work is in flight) |
+| Backlog | `ROADMAP.md` |
+| <topic> | `<file>` |
+
+## Directory map
+
+- `docs/decisions/` — ADRs (why non-obvious choices exist).
+- `docs/specs/active/` — in-flight specifications (each has a `Status:`).
+- `docs/specs/completed/` — shipped specifications.
+- `docs/specs/archive/` — historical / superseded (labeled historical).
+- `<dir>` — <purpose>.
+
+## Archive policy
+
+Anything no longer current truth moves to an archive location and is explicitly
+labeled historical, or is left as a tombstone stub pointing to its replacement.
+Nothing load-bearing is deleted outright.

--- a/docs/standards/repository-documentation/templates/README.template.md
+++ b/docs/standards/repository-documentation/templates/README.template.md
@@ -1,0 +1,28 @@
+# <Project Name>
+
+<One-sentence description of what this is.>
+
+## Quick start
+
+```bash
+<clone / install / run — the shortest path to a running or usable state>
+```
+
+## What it does
+
+<A short paragraph or bullet list. Human-facing. No agent policy here — that
+lives in `AGENTS.md`.>
+
+## Requirements
+
+- <runtime / tool / account>
+
+## Docs
+
+- `AGENTS.md` — canonical instructions for agents working in this repo.
+- `docs/INDEX.md` — documentation map (if present).
+- `<other key human docs>`
+
+## License / ownership
+
+<optional>

--- a/docs/standards/repository-documentation/templates/REPORT.template.md
+++ b/docs/standards/repository-documentation/templates/REPORT.template.md
@@ -1,0 +1,32 @@
+# Report — <Title>
+
+**SPEC:** `<path to the SPEC this implements>`
+**Date:** <YYYY-MM-DD>
+**Result:** PASS | PARTIAL | FAIL
+
+> The record of what an executed SPEC actually did. Written once, at closeout;
+> immutable afterward. If the project uses external report storage, keep the
+> report there and link it from the completed SPEC.
+
+## Summary
+
+<One or two sentences: what shipped.>
+
+## Files changed
+
+- `<path>` — <what/why>
+
+## Tests run
+
+| Command | Result |
+|---|---|
+| `<command>` | PASS / FAIL |
+
+## Remaining risks / follow-ups
+
+- <known issue, skipped test, or deferred item — link to a ROADMAP entry if kept>
+
+## Commit / PR
+
+- Commit: `<sha or NO_COMMIT>`
+- PR: `<url or NO_REMOTE_LOCAL_ONLY>`

--- a/docs/standards/repository-documentation/templates/ROADMAP.template.md
+++ b/docs/standards/repository-documentation/templates/ROADMAP.template.md
@@ -1,0 +1,26 @@
+# ROADMAP
+
+Vetted, intended future work. This is the backlog — triaged items worth doing,
+not a scratch list of every idea. Replaces uncontrolled `TODO.md`-style files.
+
+## Now / next
+
+- [ ] <item> — <one line of why / acceptance>
+
+## Later
+
+- [ ] <item>
+
+## Known gaps / accepted limitations
+
+Things that are *intentionally* not done, or waiting on an external dependency.
+Document them so they are not re-filed as bugs.
+
+- <gap> — <reason / what unblocks it>
+
+## Done (recent)
+
+Move shipped items here briefly, then let `CHANGELOG.md` carry the durable
+record.
+
+- <item> — <date>

--- a/docs/standards/repository-documentation/templates/SPEC.template.md
+++ b/docs/standards/repository-documentation/templates/SPEC.template.md
@@ -1,0 +1,40 @@
+# SPEC — <Title>
+
+**Status:** Draft — not yet started   <!-- required: Draft / Active / Blocked / Completed / Superseded -->
+**Date:** <YYYY-MM-DD>
+**Owner:** <who>
+
+> A specification defines one discrete piece of work. The `Status:` line above is
+> required and is checked by `repo-doc-check`. Live under `docs/specs/active/`
+> while in flight; move to `completed/` or `archive/` at closeout, leaving a
+> tombstone stub at the old path if it was relocated.
+
+## Objective
+
+<What this delivers, in one or two sentences.>
+
+## Context
+
+<Why now. What exists today. Constraints that matter.>
+
+## Non-goals
+
+- <explicitly out of scope>
+
+## Requirements
+
+1. <testable requirement>
+
+## Tests / acceptance
+
+- <how we know it works — commands, expected results>
+
+## Risks / safety
+
+- <what could break; any production-safety gate that applies>
+
+## Out
+
+Closeout: move to `docs/specs/completed/`, write a report (see
+[REPORT.template.md](REPORT.template.md)), update `HANDOFF.md`, and add a
+`CHANGELOG.md` line if released.

--- a/scripts/repo-doc-audit
+++ b/scripts/repo-doc-audit
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""repo-doc-audit — read-only documentation inventory + semantic audit prompt.
+
+Part of the CP7 Reusable Repository Documentation Standard
+(docs/standards/repository-documentation/). This tool NEVER writes to the
+repository and NEVER uses the network.
+
+It produces two things on stdout, in Markdown:
+
+  1. A DETERMINISTIC inventory — every documentation/instruction file, the
+     canonical files present/absent, harness adapters, SPEC lifecycle state,
+     and the raw output of `repo-doc-check`. These are facts.
+
+  2. A SEMANTIC AUDIT PROMPT — the questions a human or agent must answer that
+     regex and link checks CANNOT: source-of-truth conflicts, stale-vs-current
+     classification, dangerous operational instructions, and per-file
+     disposition. These are explicitly flagged as requiring judgment.
+
+The deterministic section never claims to have resolved a semantic conflict.
+The audit is complete only after the semantic prompt is answered by a reviewer.
+
+Zero third-party dependencies — standard library only.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+IGNORE = {".git", "node_modules", "venv", ".venv", "dist", "build",
+          "__pycache__", ".mypy_cache", ".pytest_cache", "vendor"}
+CANONICAL = ["README.md", "AGENTS.md", "docs/INDEX.md", "HANDOFF.md",
+             "ROADMAP.md", "CHANGELOG.md"]
+ADAPTER_GLOBS = [".cursor/rules/*.mdc", "GEMINI.md", "CLAUDE.md",
+                 ".codex/AGENTS.md", ".gemini/GEMINI.md", "opencode.json*"]
+
+
+def sh(args, cwd):
+    try:
+        return subprocess.run(args, cwd=cwd, capture_output=True,
+                              text=True).stdout.strip()
+    except Exception:
+        return ""
+
+
+def find_root(explicit):
+    if explicit:
+        return Path(explicit).resolve()
+    top = sh(["git", "rev-parse", "--show-toplevel"], Path.cwd())
+    return Path(top).resolve() if top else Path.cwd().resolve()
+
+
+def md_files(root):
+    out = []
+    for p in sorted(root.rglob("*.md")):
+        if any(part in IGNORE for part in p.relative_to(root).parts):
+            continue
+        out.append(p.relative_to(root))
+    return out
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(
+        prog="repo-doc-audit",
+        description="Read-only documentation inventory + semantic audit prompt. "
+                    "Never writes files; never uses the network.",
+        epilog="Example:\n  repo-doc-audit --root . > audit-<project>-<date>.md",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--root", help="repo root (default: git toplevel or cwd)")
+    ap.add_argument("--check-cmd", default=None,
+                    help="path to repo-doc-check (default: sibling of this script)")
+    args = ap.parse_args(argv)
+
+    root = find_root(args.root)
+    if not root.is_dir():
+        print(f"error: not a directory: {root}", file=sys.stderr)
+        return 2
+
+    check_cmd = args.check_cmd or str(Path(__file__).resolve().parent / "repo-doc-check")
+    branch = sh(["git", "rev-parse", "--abbrev-ref", "HEAD"], root)
+    head = sh(["git", "rev-parse", "--short", "HEAD"], root)
+    dirty = sh(["git", "status", "--porcelain"], root)
+
+    docs = md_files(root)
+    present = [f for f in CANONICAL if (root / f).exists()]
+    absent = [f for f in CANONICAL if not (root / f).exists()]
+    adapters = []
+    for g in ADAPTER_GLOBS:
+        adapters += [p.relative_to(root) for p in sorted(root.glob(g)) if p.is_file()]
+
+    specs_dir = root / "docs" / "specs"
+    lifecycle = {}
+    if specs_dir.is_dir():
+        for sub in ("active", "completed", "archive"):
+            d = specs_dir / sub
+            lifecycle[sub] = sorted(p.name for p in d.glob("*.md")) if d.is_dir() else None
+        flat = sorted(p.name for p in specs_dir.glob("*.md"))
+        lifecycle["_flat"] = flat
+
+    p = print
+    p(f"# Documentation Audit — {root.name}")
+    p("")
+    p(f"- **Repo:** `{root}`")
+    p(f"- **Branch / HEAD:** `{branch}` @ `{head}`")
+    p(f"- **Working tree:** {'DIRTY' if dirty else 'clean'}")
+    p(f"- **Markdown files found:** {len(docs)}")
+    p("")
+    p("> This report has two halves. **Part 1 is deterministic fact.** "
+      "**Part 2 requires a human/agent reviewer** — the tool does not and "
+      "cannot resolve source-of-truth or staleness questions by itself.")
+    p("")
+
+    p("## Part 1 — Deterministic inventory (facts)")
+    p("")
+    p("### Canonical files")
+    p("")
+    p("| File | Present |")
+    p("|---|---|")
+    for f in CANONICAL:
+        p(f"| `{f}` | {'yes' if f in present else 'NO'} |")
+    p("")
+    p("### Harness adapters")
+    if adapters:
+        for a in adapters:
+            p(f"- `{a}`")
+    else:
+        p("- none found (harnesses read the canonical file directly, if supported)")
+    p("")
+    if lifecycle:
+        p("### SPEC lifecycle (`docs/specs/`)")
+        p("")
+        for sub in ("active", "completed", "archive"):
+            v = lifecycle.get(sub)
+            if v is None:
+                p(f"- `{sub}/`: **missing**")
+            else:
+                p(f"- `{sub}/`: {len(v)} file(s)")
+        if lifecycle.get("_flat"):
+            p(f"- flat `docs/specs/*.md`: {len(lifecycle['_flat'])} file(s) "
+              "(should be relocation stubs only)")
+        p("")
+    p("### All documentation files")
+    p("")
+    for f in docs:
+        p(f"- `{f}`")
+    p("")
+    p("### repo-doc-check output")
+    p("")
+    p("```")
+    res = subprocess.run([sys.executable, check_cmd, "--root", str(root)],
+                         capture_output=True, text=True)
+    p(res.stdout.rstrip())
+    if res.stderr.strip():
+        p(res.stderr.rstrip())
+    p(f"(exit {res.returncode})")
+    p("```")
+    p("")
+
+    p("## Part 2 — Semantic audit prompt (requires reviewer judgment)")
+    p("")
+    p("Copy this section into an audit task for an agent or answer it yourself. "
+      "None of these can be settled by the deterministic checker.")
+    p("")
+    q = [
+        "**Source-of-truth conflicts** — do any two files give conflicting "
+        "instructions (workflow, ports, deploy, data rules)? Which one is canon?",
+        "**Link/reference tracing** — beyond broken links, do references point "
+        "at the *intended* target, or a superseded doc that still exists?",
+        "**Stale vs current** — for each doc: is it current truth, historical "
+        "record, or drifted? List the ones that describe retired behavior.",
+        "**Dangerous operational instructions** — any command that could "
+        "restart a service, write live data, run a migration, or deploy, that "
+        "is not gated behind explicit human approval?",
+        "**Per-file disposition** — for every file in Part 1, recommend: keep / "
+        "update / move to archive / merge into canon / delete (with reason).",
+        "**Unknown human decisions** — list every choice that needs Chris "
+        "(retire X? canonical owner of Y? terminology rename?).",
+    ]
+    for i, item in enumerate(q, 1):
+        p(f"{i}. {item}")
+    p("")
+    p("> Reminder: this audit performs **no repository mutation**. Any changes "
+      "belong in a separate, reviewed adoption SPEC "
+      "(see `docs/standards/repository-documentation/ADOPTION.md`).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/repo-doc-check
+++ b/scripts/repo-doc-check
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""repo-doc-check — deterministic, read-only repository documentation checks.
+
+Part of the CP7 Reusable Repository Documentation Standard
+(docs/standards/repository-documentation/). This tool NEVER writes to the
+repository and NEVER requires network access. It is safe to run in CI or
+locally. It reports OK/WARN/FAIL lines and a final `result: PASS` or
+`result: FAIL`, exiting 0 on PASS and 1 on FAIL.
+
+What it does NOT do: it does not resolve semantic conflicts, judge whether a
+document is stale, or decide source-of-truth disputes. Those require the
+read-only semantic audit (`repo-doc-audit`) plus agent/human review.
+
+Configuration is per-project via a JSON file (default `.repo-doc.json` at the
+repo root). Every key is optional; sensible defaults apply when the file is
+absent, so a small project needs no config at all. See
+`docs/standards/repository-documentation/AUDIT.md` for the full config schema.
+
+Zero third-party dependencies — standard library only.
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# --------------------------------------------------------------------------- #
+# Defaults — a project with no .repo-doc.json still gets a useful baseline.
+# --------------------------------------------------------------------------- #
+DEFAULTS = {
+    # Files that must exist for the check to pass.
+    "required_files": ["README.md", "AGENTS.md"],
+    # The one canonical agent-instruction file every adapter must point at.
+    "canonical_agents_file": "AGENTS.md",
+    # Active-work tracker size budget. `required: false` means absence is OK
+    # (no active work == no HANDOFF), but if present it must fit the budget.
+    "handoff": {
+        "file": "HANDOFF.md",
+        "required": False,
+        "warn_lines": 200,
+        "fail_lines": 400,
+    },
+    # Documentation index. Optional by default; small repos may not need one.
+    "index": {
+        "file": "docs/INDEX.md",
+        "required": False,
+        "must_reference": [],
+    },
+    # SPEC lifecycle. Disabled unless the project uses specifications.
+    "specs": {
+        "enabled": False,
+        "active_dir": "docs/specs/active",
+        "completed_dir": "docs/specs/completed",
+        "archive_dir": "docs/specs/archive",
+        "status_scan_lines": 45,
+    },
+    # Thin harness adapters. Any that exist must reference the canonical file.
+    # Globs allowed. This list is a superset; missing ones are simply skipped.
+    "adapters": {
+        "candidates": [
+            ".cursor/rules/*.mdc",
+            "GEMINI.md",
+            "CLAUDE.md",
+            ".codex/AGENTS.md",
+            ".gemini/GEMINI.md",
+        ],
+        "require_at_least_one": False,
+    },
+    # Relative Markdown link / path-reference checking (in-repo scope only).
+    "link_check": {
+        "enabled": True,
+        "scan": ["AGENTS.md", "README.md", "docs/INDEX.md", "ROADMAP.md"],
+        "allowlist": [],
+    },
+    # Uncontrolled, ambiguous filenames the standard prohibits. Globs allowed,
+    # matched case-insensitively against the file's basename.
+    "forbidden_filenames": [
+        "FINAL_NOTES.md",
+        "LATEST_PLAN.md",
+        "NEW_HANDOFF.md",
+        "FINAL_*.md",
+        "*_FINAL.md",
+        "LATEST_*.md",
+        "NEW_*.md",
+        "*_NEW.md",
+        "*-old.md",
+        "*_old.md",
+        "*.md.bak",
+    ],
+    # Project-configured stale terms to flag if they appear in scanned docs.
+    "forbidden_terms": [],
+    # Directories never scanned for links or forbidden names.
+    "ignore_dirs": [
+        ".git", "node_modules", "venv", ".venv", "dist", "build",
+        "__pycache__", ".mypy_cache", ".pytest_cache", "vendor",
+    ],
+}
+
+MD_LINK = re.compile(r"(?<!!)\[[^\]]*\]\(([^)]+)\)")
+BACKTICK = re.compile(r"`([^`\n]+)`")
+FENCE = re.compile(r"```.*?```", re.DOTALL)
+PATH_PREFIXES = ("docs/", "scripts/", "src/", "tests/", ".github/", ".cursor/",
+                 ".claude/", ".codex/", "frontend/", "bin/")
+
+
+class Report:
+    def __init__(self) -> None:
+        self.fail = 0
+        self.warn = 0
+
+    def ok(self, msg: str) -> None:
+        print(f"OK: {msg}")
+
+    def warn_(self, msg: str) -> None:
+        print(f"WARN: {msg}")
+        self.warn += 1
+
+    def fail_(self, msg: str) -> None:
+        print(f"FAIL: {msg}")
+        self.fail += 1
+
+
+def deep_merge(base: dict, override: dict) -> dict:
+    out = dict(base)
+    for k, v in override.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def find_root(explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit).resolve()
+    try:
+        top = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        if top:
+            return Path(top).resolve()
+    except Exception:
+        pass
+    return Path.cwd().resolve()
+
+
+def load_config(root: Path, explicit: str | None) -> dict:
+    path = Path(explicit) if explicit else root / ".repo-doc.json"
+    if path.is_file():
+        try:
+            user = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            print(f"FAIL: invalid config JSON in {path}: {exc}")
+            sys.exit(2)
+        cfg = deep_merge(DEFAULTS, user)
+        cfg["_config_source"] = str(path)
+    else:
+        cfg = deep_merge(DEFAULTS, {})
+        cfg["_config_source"] = "built-in defaults"
+    return cfg
+
+
+def iter_files(root: Path, ignore_dirs: list[str]):
+    ignore = set(ignore_dirs)
+    for p in root.rglob("*"):
+        if any(part in ignore for part in p.relative_to(root).parts):
+            continue
+        if p.is_file():
+            yield p
+
+
+# --------------------------------------------------------------------------- #
+# Individual checks
+# --------------------------------------------------------------------------- #
+def check_required_files(root: Path, cfg: dict, rep: Report) -> None:
+    for rel in cfg["required_files"]:
+        if (root / rel).exists():
+            rep.ok(f"required file present: {rel}")
+        else:
+            rep.fail_(f"required file missing: {rel}")
+
+
+def _strip_url(url: str) -> str:
+    url = url.strip().strip("<>").strip()
+    if " " in url and not url.startswith("./"):
+        url = url.split()[0]
+    return url.split("#", 1)[0].split("?", 1)[0].strip()
+
+
+def _is_local_ref(s: str) -> bool:
+    if not s or s.startswith(("http://", "https://", "mailto:", "#", "/", "tel:")):
+        return False
+    if any(c in s for c in "\n\r *?<>|") or " " in s:
+        return False
+    return True
+
+
+def _looks_like_repo_path(s: str) -> bool:
+    return s.startswith("./") or s.startswith(PATH_PREFIXES) or (
+        s.endswith((".md", ".py", ".sh", ".yml", ".yaml", ".json", ".sql", ".toml"))
+        and "/" not in s.strip("./")
+    ) or "/" in s
+
+
+def check_links(root: Path, cfg: dict, rep: Report) -> None:
+    lc = cfg["link_check"]
+    if not lc.get("enabled", True):
+        return
+    allow = set(lc.get("allowlist", []))
+    checked = 0
+    missing = []
+    for rel in lc["scan"]:
+        f = root / rel
+        if not f.is_file():
+            continue  # absence handled by required_files / index checks
+        text = FENCE.sub("", f.read_text(encoding="utf-8", errors="replace"))
+        refs = {_strip_url(m.group(1)) for m in MD_LINK.finditer(text)}
+        refs |= {m.group(1).strip() for m in BACKTICK.finditer(text)}
+        for ref in sorted(refs):
+            if not _is_local_ref(ref) or not _looks_like_repo_path(ref):
+                continue
+            norm = ref[2:] if ref.startswith("./") else ref
+            if ref in allow or norm in allow:
+                continue
+            checked += 1
+            cand = [(f.parent / ref), (root / norm)]
+            if not any(c.exists() for c in cand):
+                missing.append((rel, ref))
+    rep.ok(f"path/link references checked: {checked}")
+    for src, ref in missing:
+        rep.fail_(f"broken reference in {src}: {ref}")
+
+
+def check_handoff(root: Path, cfg: dict, rep: Report) -> None:
+    h = cfg["handoff"]
+    f = root / h["file"]
+    if not f.is_file():
+        if h.get("required"):
+            rep.fail_(f"required active-work tracker missing: {h['file']}")
+        else:
+            rep.ok(f"{h['file']} absent (no active work — allowed)")
+        return
+    lines = len(f.read_text(encoding="utf-8", errors="replace").splitlines())
+    if lines > h["fail_lines"]:
+        rep.fail_(f"{h['file']} has {lines} lines (> fail budget {h['fail_lines']}); archive old sessions")
+    elif lines > h["warn_lines"]:
+        rep.warn_(f"{h['file']} has {lines} lines (> target {h['warn_lines']})")
+    else:
+        rep.ok(f"{h['file']} size {lines} lines (<= {h['warn_lines']})")
+
+
+def check_index(root: Path, cfg: dict, rep: Report) -> None:
+    idx = cfg["index"]
+    f = root / idx["file"]
+    if not f.is_file():
+        if idx.get("required"):
+            rep.fail_(f"required documentation index missing: {idx['file']}")
+        else:
+            rep.ok(f"{idx['file']} absent (optional)")
+        return
+    text = f.read_text(encoding="utf-8", errors="replace")
+    for ref in idx.get("must_reference", []):
+        if ref in text:
+            rep.ok(f"index references {ref}")
+        else:
+            rep.fail_(f"index {idx['file']} must reference {ref}")
+
+
+def check_specs(root: Path, cfg: dict, rep: Report) -> None:
+    s = cfg["specs"]
+    if not s.get("enabled"):
+        return
+    active = root / s["active_dir"]
+    completed = root / s["completed_dir"]
+    scan_lines = s.get("status_scan_lines", 45)
+    status_re = re.compile(r"^(\*\*)?Status(\*\*)?\s*[:=]", re.IGNORECASE)
+    for label, d in (("active", active), ("completed", completed)):
+        if not d.is_dir():
+            if label == "active":
+                rep.warn_(f"specs enabled but {s['active_dir']} does not exist")
+            continue
+        for f in sorted(d.glob("*.md")):
+            if f.name == "README.md":
+                continue
+            head = "\n".join(f.read_text(encoding="utf-8", errors="replace").splitlines()[:scan_lines])
+            if any(status_re.match(ln) for ln in head.splitlines()):
+                rep.ok(f"{label} SPEC has Status: {f.relative_to(root)}")
+            else:
+                rep.fail_(f"{label} SPEC missing Status: line: {f.relative_to(root)}")
+
+
+def check_adapters(root: Path, cfg: dict, rep: Report) -> None:
+    a = cfg["adapters"]
+    canon = cfg["canonical_agents_file"]
+    found = []
+    for pattern in a["candidates"]:
+        for f in sorted(root.glob(pattern)):
+            if f.is_file():
+                found.append(f)
+    if not found:
+        if a.get("require_at_least_one"):
+            rep.fail_("no harness adapters found but require_at_least_one is set")
+        else:
+            rep.ok("no harness adapters present (allowed)")
+        return
+    for f in found:
+        rel = f.relative_to(root)
+        if f.is_symlink():
+            target = f.readlink().name if hasattr(f, "readlink") else Path(str(f)).resolve().name
+            if target == canon:
+                rep.ok(f"adapter {rel} -> {canon} (symlink)")
+                continue
+        text = f.read_text(encoding="utf-8", errors="replace")
+        if re.search(re.escape(canon), text):
+            rep.ok(f"adapter {rel} references {canon}")
+        else:
+            rep.fail_(f"adapter {rel} must reference the canonical {canon}")
+
+
+def check_forbidden(root: Path, cfg: dict, rep: Report) -> None:
+    patterns = cfg["forbidden_filenames"]
+    ignore = cfg["ignore_dirs"]
+    # never flag files inside a spec archive — those are historical by design.
+    archive = cfg["specs"].get("archive_dir", "")
+    hits = []
+    for f in iter_files(root, ignore):
+        rel = f.relative_to(root)
+        if archive and str(rel).startswith(archive + "/"):
+            continue
+        base = f.name
+        for pat in patterns:
+            if fnmatch.fnmatch(base.lower(), pat.lower()):
+                hits.append((str(rel), pat))
+                break
+    if hits:
+        for rel, pat in hits:
+            rep.fail_(f"forbidden/uncontrolled filename: {rel} (matches '{pat}')")
+    else:
+        rep.ok("no forbidden/uncontrolled filenames")
+
+
+def check_forbidden_terms(root: Path, cfg: dict, rep: Report) -> None:
+    terms = cfg.get("forbidden_terms", [])
+    if not terms:
+        return
+    scan = cfg["link_check"]["scan"]
+    hits = []
+    for rel in scan:
+        f = root / rel
+        if not f.is_file():
+            continue
+        text = f.read_text(encoding="utf-8", errors="replace")
+        for term in terms:
+            if term in text:
+                hits.append((rel, term))
+    if hits:
+        for rel, term in hits:
+            rep.fail_(f"stale/forbidden term '{term}' found in {rel}")
+    else:
+        rep.ok("no configured forbidden terms present")
+
+
+CHECKS = [
+    ("required-files", check_required_files),
+    ("links", check_links),
+    ("handoff-budget", check_handoff),
+    ("index", check_index),
+    ("spec-status", check_specs),
+    ("adapters", check_adapters),
+    ("forbidden-filenames", check_forbidden),
+    ("forbidden-terms", check_forbidden_terms),
+]
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(
+        prog="repo-doc-check",
+        description="Read-only documentation checks for the CP7 repository "
+                    "documentation standard. Never writes files; never uses "
+                    "the network. Exits 0 on PASS, 1 on FAIL.",
+        epilog="Example:\n"
+               "  repo-doc-check --root . \n"
+               "  repo-doc-check --config .repo-doc.json\n"
+               "  repo-doc-check --list-checks",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--root", help="repo root (default: git toplevel or cwd)")
+    ap.add_argument("--config", help="config JSON path (default: <root>/.repo-doc.json)")
+    ap.add_argument("--list-checks", action="store_true", help="print check names and exit")
+    ap.add_argument("--print-config", action="store_true", help="print effective config and exit")
+    args = ap.parse_args(argv)
+
+    if args.list_checks:
+        for name, _ in CHECKS:
+            print(name)
+        return 0
+
+    root = find_root(args.root)
+    cfg = load_config(root, args.config)
+
+    if args.print_config:
+        printable = {k: v for k, v in cfg.items() if not k.startswith("_")}
+        print(json.dumps(printable, indent=2))
+        return 0
+
+    if not root.is_dir():
+        print(f"FAIL: root is not a directory: {root}")
+        return 2
+
+    print(f"repo-doc-check (read-only) root={root}")
+    print(f"config: {cfg['_config_source']}")
+    print("----")
+    rep = Report()
+    for _, fn in CHECKS:
+        fn(root, cfg, rep)
+    print("----")
+    if rep.fail:
+        print(f"result: FAIL ({rep.fail} failure(s), {rep.warn} warning(s))")
+        return 1
+    print(f"result: PASS ({rep.warn} warning(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/repo-doc-tests/fixtures/bad-adapter/AGENTS.md
+++ b/scripts/repo-doc-tests/fixtures/bad-adapter/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md — Bad Adapter Fixture
+
+Canonical instructions. Overview in `README.md`.

--- a/scripts/repo-doc-tests/fixtures/bad-adapter/GEMINI.md
+++ b/scripts/repo-doc-tests/fixtures/bad-adapter/GEMINI.md
@@ -1,0 +1,4 @@
+# Gemini instructions
+
+This adapter restates its own policy and never points at the canonical file,
+which is exactly the duplication the standard forbids.

--- a/scripts/repo-doc-tests/fixtures/bad-adapter/README.md
+++ b/scripts/repo-doc-tests/fixtures/bad-adapter/README.md
@@ -1,0 +1,3 @@
+# Bad Adapter Fixture
+
+See `AGENTS.md`. `GEMINI.md` fails to point back at it, which must FAIL.

--- a/scripts/repo-doc-tests/fixtures/broken-link/AGENTS.md
+++ b/scripts/repo-doc-tests/fixtures/broken-link/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS.md — Broken Link Fixture
+
+This document links to [a file that does not exist](./nope.md), which must
+make the checker FAIL on a broken relative reference.

--- a/scripts/repo-doc-tests/fixtures/broken-link/README.md
+++ b/scripts/repo-doc-tests/fixtures/broken-link/README.md
@@ -1,0 +1,3 @@
+# Broken Link Fixture
+
+See `AGENTS.md`.

--- a/scripts/repo-doc-tests/fixtures/forbidden-name/AGENTS.md
+++ b/scripts/repo-doc-tests/fixtures/forbidden-name/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md — Forbidden Name Fixture
+
+Canonical instructions. Overview in `README.md`.

--- a/scripts/repo-doc-tests/fixtures/forbidden-name/FINAL_NOTES.md
+++ b/scripts/repo-doc-tests/fixtures/forbidden-name/FINAL_NOTES.md
@@ -1,0 +1,3 @@
+# Final Notes
+
+An uncontrolled, ambiguous planning file the standard prohibits by name.

--- a/scripts/repo-doc-tests/fixtures/forbidden-name/README.md
+++ b/scripts/repo-doc-tests/fixtures/forbidden-name/README.md
@@ -1,0 +1,3 @@
+# Forbidden Name Fixture
+
+See `AGENTS.md`. Contains an uncontrolled `FINAL_NOTES.md` which must FAIL.

--- a/scripts/repo-doc-tests/fixtures/missing-canonical/README.md
+++ b/scripts/repo-doc-tests/fixtures/missing-canonical/README.md
@@ -1,0 +1,3 @@
+# Missing Canonical Fixture
+
+This repo is missing `AGENTS.md`, so the checker must FAIL.

--- a/scripts/repo-doc-tests/fixtures/missing-spec-status/.repo-doc.json
+++ b/scripts/repo-doc-tests/fixtures/missing-spec-status/.repo-doc.json
@@ -1,0 +1,3 @@
+{
+  "specs": { "enabled": true }
+}

--- a/scripts/repo-doc-tests/fixtures/missing-spec-status/AGENTS.md
+++ b/scripts/repo-doc-tests/fixtures/missing-spec-status/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md — Missing SPEC Status Fixture
+
+Canonical instructions. Overview in `README.md`.

--- a/scripts/repo-doc-tests/fixtures/missing-spec-status/README.md
+++ b/scripts/repo-doc-tests/fixtures/missing-spec-status/README.md
@@ -1,0 +1,3 @@
+# Missing SPEC Status Fixture
+
+See `AGENTS.md`. This project uses specs (`.repo-doc.json` enables them).

--- a/scripts/repo-doc-tests/fixtures/missing-spec-status/docs/specs/active/no-status.md
+++ b/scripts/repo-doc-tests/fixtures/missing-spec-status/docs/specs/active/no-status.md
@@ -1,0 +1,8 @@
+# SPEC — Example Without a Status Line
+
+This active SPEC deliberately omits the required `Status:` line, so the
+checker must FAIL it.
+
+## Objective
+
+Demonstrate the spec-status check.

--- a/scripts/repo-doc-tests/fixtures/oversized-handoff/.repo-doc.json
+++ b/scripts/repo-doc-tests/fixtures/oversized-handoff/.repo-doc.json
@@ -1,0 +1,3 @@
+{
+  "handoff": { "file": "HANDOFF.md", "required": true, "warn_lines": 2, "fail_lines": 5 }
+}

--- a/scripts/repo-doc-tests/fixtures/oversized-handoff/AGENTS.md
+++ b/scripts/repo-doc-tests/fixtures/oversized-handoff/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md — Oversized HANDOFF Fixture
+
+Canonical instructions. Overview in `README.md`.

--- a/scripts/repo-doc-tests/fixtures/oversized-handoff/HANDOFF.md
+++ b/scripts/repo-doc-tests/fixtures/oversized-handoff/HANDOFF.md
@@ -1,0 +1,10 @@
+# HANDOFF
+
+line 1
+line 2
+line 3
+line 4
+line 5
+line 6
+line 7
+line 8

--- a/scripts/repo-doc-tests/fixtures/oversized-handoff/README.md
+++ b/scripts/repo-doc-tests/fixtures/oversized-handoff/README.md
@@ -1,0 +1,3 @@
+# Oversized HANDOFF Fixture
+
+See `AGENTS.md`. `.repo-doc.json` sets a tiny HANDOFF budget to force a FAIL.

--- a/scripts/repo-doc-tests/fixtures/thin-adapter/AGENTS.md
+++ b/scripts/repo-doc-tests/fixtures/thin-adapter/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md — Thin Adapter Fixture
+
+Canonical instructions. Overview in `README.md`.

--- a/scripts/repo-doc-tests/fixtures/thin-adapter/CLAUDE.md
+++ b/scripts/repo-doc-tests/fixtures/thin-adapter/CLAUDE.md
@@ -1,0 +1,4 @@
+# Claude adapter
+
+This file is a thin pointer. The canonical instructions live in `AGENTS.md` —
+read that. Do not duplicate policy here.

--- a/scripts/repo-doc-tests/fixtures/thin-adapter/README.md
+++ b/scripts/repo-doc-tests/fixtures/thin-adapter/README.md
@@ -1,0 +1,3 @@
+# Thin Adapter Fixture
+
+See `AGENTS.md`. `CLAUDE.md` is a thin pointer to it.

--- a/scripts/repo-doc-tests/fixtures/valid-minimal/AGENTS.md
+++ b/scripts/repo-doc-tests/fixtures/valid-minimal/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS.md — Valid Minimal Fixture
+
+Canonical agent instructions. The overview lives in `README.md`.
+
+This project has no active work, no specs, and no harness adapters — which is
+a valid, passing baseline under the standard.

--- a/scripts/repo-doc-tests/fixtures/valid-minimal/README.md
+++ b/scripts/repo-doc-tests/fixtures/valid-minimal/README.md
@@ -1,0 +1,3 @@
+# Valid Minimal Fixture
+
+A tiny repo that satisfies the baseline. See `AGENTS.md` for agent context.

--- a/scripts/repo-doc-tests/run-tests.sh
+++ b/scripts/repo-doc-tests/run-tests.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# run-tests.sh — fixture tests for repo-doc-check / repo-doc-audit.
+#
+# Read-only: runs the tools against fixture repos under ./fixtures and asserts
+# the expected PASS/FAIL result. No network, no mutation, no dependencies
+# beyond bash + python3. Exits 0 when all cases pass, 1 otherwise.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")" && pwd)"
+SCRIPTS="$(cd "$HERE/.." && pwd)"
+CHECK="$SCRIPTS/repo-doc-check"
+AUDIT="$SCRIPTS/repo-doc-audit"
+FIX="$HERE/fixtures"
+
+pass=0
+fail=0
+
+# assert_result <fixture> <expected-exit> <label>
+assert_result() {
+  local fx="$1" want="$2" label="$3" rc=0
+  python3 "$CHECK" --root "$FIX/$fx" >/dev/null 2>&1 || rc=$?
+  if [[ "$rc" -eq "$want" ]]; then
+    echo "PASS: $label ($fx -> exit $rc)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: $label ($fx -> exit $rc, wanted $want)"
+    echo "----- full output -----"
+    python3 "$CHECK" --root "$FIX/$fx" || true
+    echo "-----------------------"
+    fail=$((fail + 1))
+  fi
+}
+
+echo "== repo-doc-check --help =="
+python3 "$CHECK" --help >/dev/null && echo "PASS: check --help" && pass=$((pass + 1)) \
+  || { echo "FAIL: check --help"; fail=$((fail + 1)); }
+
+echo "== repo-doc-audit --help =="
+python3 "$AUDIT" --help >/dev/null && echo "PASS: audit --help" && pass=$((pass + 1)) \
+  || { echo "FAIL: audit --help"; fail=$((fail + 1)); }
+
+echo "== fixture cases =="
+assert_result valid-minimal        0 "valid minimal project passes"
+assert_result missing-canonical    1 "missing canonical AGENTS.md fails"
+assert_result broken-link          1 "broken relative link fails"
+assert_result missing-spec-status  1 "active SPEC without Status: fails"
+assert_result oversized-handoff    1 "oversized HANDOFF fails when configured"
+assert_result thin-adapter         0 "thin adapter referencing AGENTS.md passes"
+assert_result bad-adapter          1 "adapter not referencing AGENTS.md fails"
+assert_result forbidden-name       1 "uncontrolled filename fails"
+
+echo "== repo-doc-audit smoke (read-only, no mutation) =="
+before="$(find "$FIX/valid-minimal" -type f | sort | xargs sha256sum 2>/dev/null | sha256sum)"
+python3 "$AUDIT" --root "$FIX/valid-minimal" >/dev/null
+after="$(find "$FIX/valid-minimal" -type f | sort | xargs sha256sum 2>/dev/null | sha256sum)"
+if [[ "$before" == "$after" ]]; then
+  echo "PASS: audit made no changes to the fixture"
+  pass=$((pass + 1))
+else
+  echo "FAIL: audit modified the fixture"
+  fail=$((fail + 1))
+fi
+
+echo "----"
+echo "result: $pass passed, $fail failed"
+[[ "$fail" -eq 0 ]] || exit 1
+echo "result: PASS"


### PR DESCRIPTION
## Summary

Generalizes the proven Empower documentation model (PRs #453–#460) into a
reusable, agent-agnostic **CP7 Repository Documentation Standard** plus a
deterministic read-only checker, a read-only semantic-audit tool, adoption &
maintenance procedures, and a project rollout inventory.

**This PR ships the shared standard only. It migrates no other project and
changes no runtime/service/data state. Do not merge without review.**

## Selected canonical host and why

**`project-playbook`.** It is the version-controlled owner of the cross-project
*documentation/workflow methodology* ("spec → task → build → verify used across
cp7 projects") and has a working GitHub remote so this review PR can exist.

The Agent Control Plane (ACP) owns cross-agent *runtime* policy (rules 00–80,
roles, `projects.json`), but has **no git remote**, so it cannot host a review
PR — and a documentation *structure* standard is methodology, not runtime
gating. The standard therefore lives here and **references** ACP's rules rather
than duplicating them. (Host confirmed with the operator before implementation.)

## Artifact tree

```
docs/standards/repository-documentation/
├── STANDARD.md          # universal rules, required/optional structure, separation of concerns
├── TERMINOLOGY.md       # one word one meaning; prohibited names
├── ADOPTION.md          # staged, one-project-at-a-time rollout
├── AUDIT.md             # read-only audit + full .repo-doc.json config schema
├── MAINTENANCE.md       # drift prevention; semver + changelog + migration notes
├── PROJECT-INVENTORY.md # read-only fleet inventory + rollout waves
├── templates/           # AGENTS, README, INDEX, HANDOFF, ROADMAP, SPEC, REPORT, ADR
└── examples/minimal-project-tree.md
scripts/
├── repo-doc-check       # deterministic, read-only, zero-dependency doc gate
├── repo-doc-audit       # read-only inventory + semantic audit prompt
└── repo-doc-tests/      # fixtures (pass + fail) + run-tests.sh
```

## Universal vs optional rules

**Universal (every repo):** one canonical `AGENTS.md`; a `README.md`; thin
harness adapters that point at `AGENTS.md` (no copied policy); one meaning per
term; one source of truth per fact; active work tracked + closed out; history
labeled; docs pass `repo-doc-check`.

**Required baseline:** `README.md`, `AGENTS.md`; `docs/INDEX.md` once docs grow;
`HANDOFF.md` **only while work is active**; `ROADMAP.md` when there is a backlog;
spec lifecycle dirs when the project uses specs.

**Optional/conditional:** architecture, testing, operations, deployment, ADRs,
reports, changelog, harness adapters. **No empty files are ever required** to
satisfy a template. Compatible with repos that have no database/frontend/
service/worktree/deploy checkout.

## Checker architecture & configuration

`repo-doc-check` (Python stdlib only) runs eight read-only checks:
`required-files, links, handoff-budget, index, spec-status, adapters,
forbidden-filenames, forbidden-terms`. It prints `OK/WARN/FAIL` lines and a
terminal `result: PASS`/`result: FAIL`, exiting `0`/`1` (`2` on usage/config
error). **No mutation, no network, no dependencies.**

Per-project behavior comes from an optional `.repo-doc.json` deep-merged over
defaults (scales from zero-config small repos to complex multi-service repos) —
**configure, don't fork the script.** Full schema in `AUDIT.md`.

`repo-doc-audit` emits a deterministic inventory **plus** a semantic audit prompt
and explicitly does **not** claim regex/link checks can resolve source-of-truth
or staleness conflicts — those need agent/human review.

## Test results

- `bash scripts/repo-doc-tests/run-tests.sh` → **11/11 PASS** (both tool
  `--help`; valid-minimal passes; missing-canonical, broken-link,
  missing-spec-status, oversized-handoff, bad-adapter, forbidden-name all fail;
  thin-adapter passes; audit made no fixture changes).
- `python3 -m py_compile` on both tools → OK.
- Internal kit cross-links → 0 broken.
- `git diff --check` → clean.
- Empower-specific-token scan of generic templates/tools → clean.
- CI preflight (secret + db-file scan) mirrored locally → clean.

## First rollout recommendations (Wave 1, 5 projects)

Manageable risk + representative of distinct archetypes:
`project-playbook` (dogfood the host), `playbook-cli` (Python CLI / small
baseline), `531-pwa` (frontend), `cc-loop` (agent tooling), `service-register`
(small backend). Live/prod-sensitive services (context-engine-v2, honcho,
firecrawl, hermes-workspace, netmon) are deferred to Wave 3 with careful
per-project audits; Empower is the reference implementation and needs no
adoption. Full table in `PROJECT-INVENTORY.md`.

## Confirmation: no project migrated

No other repository was modified. Empower untouched. No CI added to any project
repo. No service/container/timer/db/deploy/permission change. The only host-repo
touches are additive: the standard kit, a README pointer, and a CHANGELOG entry.

## Acceptance-gate table

| # | Gate | Result |
|---|---|---|
| 1 | Canonical shared host verified | PASS (project-playbook; ACP has no remote — operator-confirmed) |
| 2 | One isolated task branch/worktree | PASS |
| 3 | Existing standards integrated, not duplicated | PASS (references ACP + PLAYBOOK + existing ADR template) |
| 4 | All required deliverables exist and cross-link | PASS (0 broken internal links) |
| 5 | Universal vs project-specific separated | PASS |
| 6 | Templates concise & internally consistent | PASS |
| 7 | Checker read-only, configurable, tested | PASS (11/11 fixtures) |
| 8 | Audit separates deterministic vs semantic | PASS |
| 9 | Adoption & maintenance complete | PASS |
| 10 | Inventory + first wave included | PASS |
| 11 | All required tests pass | PASS |
| 12 | One focused commit pushed, no force | PASS |
| 13 | One PR opened, not merged | PASS (this PR) |
| 14 | No runtime/deploy/db/service/timer/process state changed | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiCQSYoDscQUjitLpwXnMC
